### PR TITLE
Make Restart Great Again

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1399,7 +1399,7 @@ namespace Content.Shared.CCVar
         ///     Config for when the restart vote should be allowed to be called based on percentage of ghosts.
         ///
         public static readonly CVarDef<int> VoteRestartGhostPercentage =
-            CVarDef.Create("vote.restart_ghost_percentage", 50, CVar.SERVERONLY);
+            CVarDef.Create("vote.restart_ghost_percentage", 10, CVar.SERVERONLY);
 
         /// <summary>
         ///     See vote.enabled, but specific to preset votes
@@ -1417,7 +1417,7 @@ namespace Content.Shared.CCVar
         ///     The required ratio of the server that must agree for a restart round vote to go through.
         /// </summary>
         public static readonly CVarDef<float> VoteRestartRequiredRatio =
-            CVarDef.Create("vote.restart_required_ratio", 0.85f, CVar.SERVERONLY);
+            CVarDef.Create("vote.restart_required_ratio", 0.75f, CVar.SERVERONLY);
 
         /// <summary>
         /// Whether or not to prevent the restart vote from having any effect when there is an online admin


### PR DESCRIPTION
This PR's sole purpose is restoring my sanity and was made out of spite.
- Restart vote requirement lowered to 75% from 85% to make holding the entire server hostage more difficult.
- Required ghost percentage lowered to 10% from 50% so you don't have to slaughter the entire server just to hold a vote.

Please merge, thank you!